### PR TITLE
add opam file and fix makefile for dune

### DIFF
--- a/META
+++ b/META
@@ -1,0 +1,5 @@
+name = "agrep"
+description = "String searching with errors"
+version = "1.1"
+archive(byte) = "agrep.cma"
+archive(native) = "agrep.cmxa"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CAMLSTDLIB=`ocamlc -where`
 DESTDIR=$(CAMLSTDLIB)/agrep
+STUBDESTDIR=$(CAMLSTDLIB)/stublibs
+LIB_EXT=so
 
 OCAMLC=ocamlc -g
 OCAMLOPT=ocamlopt
@@ -25,10 +27,14 @@ install:
 	mkdir -p $(DESTDIR)
 	cp agrep.cmi agrep.cma agrep.cmxa agrep.a $(DESTDIR)
 	cp libagrep.a $(DESTDIR)
-	if test -f dllagrep.so; then cp dllagrep.so $(DESTDIR); fi
+	if test -f dllagrep.$(LIB_EXT); then cp dllagrep.$(LIB_EXT) $(STUBDESTDIR); fi
 	destdir=$(DESTDIR); ldconf=$(CAMLSTDLIB)/ld.conf; \
         if test `grep -s -c '^'$$destdir'$$' $$ldconf || :` = 0; \
         then echo $$destdir >> $$ldconf; fi
+
+find-install:
+	ocamlfind install agrep \
+		agrep.cma agrep.cmi agrep.cmxa agrep.a libagrep.a dllagrep.$(LIB_EXT) META
 
 testagrep: testagrep.ml agrep.cma libagrep.a
 	$(OCAMLC) -I . -custom -o $@ agrep.cma testagrep.ml

--- a/agrep.opam
+++ b/agrep.opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "blue-prawn"
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/ocamlagrep/"
+bug-reports: "https://github.com/xavierleroy/ocamlagrep/issues"
+dev-repo: "git+https://github.com/xavierleroy/ocamlagrep.git"
+license: "LGPL-2.0-or-later"
+build: make
+remove: [["ocamlfind" "remove" "agrep"]]
+depends: [
+  "ocaml" {< "5.0.0"}
+  "ocamlfind"
+]
+install: [
+  [make "find-install"]
+  [make "find-install" "LIB_EXT=dll"] {os = "win32" | os = "cygwin"}
+]
+synopsis: "String searching with errors"
+description: """
+This library implements the Wu-Manber algorithm for string searching
+with errors, popularized by the "agrep" Unix command and the "glimpse"
+file indexing tool."""


### PR DESCRIPTION
Hi Xavier,
The changes in the makefile are exactly those in the [opam-repository patch file](https://github.com/ocaml/opam-repository/blob/master/packages/agrep/agrep.1.0/files/find-install.patch)
with the only addition being `agrep.a` in
```
find-install:
	ocamlfind install agrep \
		agrep.cma agrep.cmi agrep.cmxa agrep.a libagrep.a dllagrep.$(LIB_EXT) META
```
which seems to be needed by dune. To be honest I'm not sure why this is needed but I'd like to use this opam package for one of my projects and this seems to work fine.

Also I changed the Ocaml upper bound from 4.06 to 5.0.

-Nathan